### PR TITLE
Set opt-level `s` for smaller .wasm size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ authors = ["Benjamin Wasty <benny.wasty@gmail.com>"]
 
 [dependencies]
 gltf = "0.9.2"
+
+[profile.release]
+# Optimize for size. The 'more agressive' `z` actually produces larger binaries
+opt-level = "s"


### PR DESCRIPTION
Found a barely documented size-optimization switch: https://github.com/rust-lang/rust/issues/35784
Before: 
<img width="435" alt="gltf-validator-wasm-size-old" src="https://user-images.githubusercontent.com/1647415/31100082-6ec9c3fa-a7c8-11e7-9f02-df7808c604ad.png">
[After](https://gltf-validator-web.netlify.com/):
<img width="437" alt="gltf-validator-wasm-size-new" src="https://user-images.githubusercontent.com/1647415/31100100-7c4cfa6a-a7c8-11e7-97c5-86c9780e5e4e.png">
(the upper is transferred size, the lower the actual size)

Opt-level `z` is supposed to be even more aggressive, but the result actually is 100KB larger actually.
